### PR TITLE
Support to Perl files and Exclusion of instructions from analyze

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ What is code2pg ?
 `code2pg` is a tool that help migrating application code that contains SQL queries from Oracle to PostgreSQL standard.
 
 It can:
-- estimate in man-days how difficult a migration will be for application code (in Java files for example);
+- estimate in person-days how difficult a migration will be for application code (in Java files for example);
 - tag the source file for Oracle instructions that might need to be migrated;
 - generate different reports: html, text or minimal;
 - connect directly to a SVN repository or use local files;
@@ -94,7 +94,7 @@ Report examples
 
 ```
 Done !
-Estimation: 0.19 man-days
+Estimation: 0.19 person-days
 ```
 
 - text output:
@@ -115,13 +115,13 @@ Settings
 Estimates
 =========
 
-|            | Number of instructions | Time/instruction | Estimated time (minutes) | Man-days |
-|------------|------------------------|------------------|--------------------------|----------|
-| Level 1    |                    265 |                1 |                      265 |      0.7 |
-| Level 2    |                     27 |                4 |                      108 |      0.3 |
-| Level 3    |                     26 |                8 |                      208 |      0.6 |
-| Level 4    |                    140 |               20 |                     2800 |      7.8 |
-| estimation |                    458 |              7.4 |                     3381 |      9.4 |
+|            | Number of instructions | Time/instruction | Estimated time (minutes) | person-days |
+|------------|------------------------|------------------|--------------------------|-------------|
+| Level 1    |                    265 |                1 |                      265 |         0.7 |
+| Level 2    |                     27 |                4 |                      108 |         0.3 |
+| Level 3    |                     26 |                8 |                      208 |         0.6 |
+| Level 4    |                    140 |               20 |                     2800 |         7.8 |
+| estimation |                    458 |              7.4 |                     3381 |         9.4 |
 
 Instructions
 ============

--- a/code2pg
+++ b/code2pg
@@ -55,6 +55,7 @@ my %LANGUAGE_COMMENTS_BEGIN = (
     "jsp"        => "<!--",
     "plsql"      => "--",
     "proc"       => "\/\/",
+    "perl"       => '#',
 );
 
 my %LANGUAGE_COMMENTS_END = (
@@ -63,6 +64,7 @@ my %LANGUAGE_COMMENTS_END = (
     "jsp"        => "-->",
     "plsql"      => "",
     "proc"       => "",
+    "perl"       => "",
 );
 
 my %REGEX_SEARCH; # how we identify keywords
@@ -3403,6 +3405,7 @@ Examples:
   ./code2pg -D svn -d https://mysvnrepo/project/trunk -l comma-strings -e java -f txt
   ./code2pg -c myconfigfile.conf
   ./code2pg -h ADD_MONTHS
+  ./code2pg -e pl -e pm --exclude-instr USER -l comma-strings
 
 };
     exit(1);

--- a/code2pg
+++ b/code2pg
@@ -3578,7 +3578,7 @@ sub terminal_output {
     my $n_lvl4             = shift;       # number of level4 instructions
     my $nb_fct_tot         = shift;
     my $estimated_load     = shift;       # estimate in minutes
-    my $estimated_load_md  = shift;       # estimate in man-days
+    my $estimated_load_md  = shift;       # estimate in person-days
     my $ext_to_analyze     = shift;       # which extensions to analyze
     my $nb_fic             = shift;
     my $total_nb_lines     = shift;
@@ -3595,41 +3595,41 @@ sub terminal_output {
 
     # Create a difficulty table
     my $tbl_output;
-    $tbl_output .= "|            | Number of instructions | Time/instruction | Estimated time (minutes) | Man-days |\n";
-    $tbl_output .= "|------------|------------------------|------------------|--------------------------|----------|\n";
+    $tbl_output .= "|            | Number of instructions | Time/instruction | Estimated time (minutes) | Person-days |\n";
+    $tbl_output .= "|------------|------------------------|------------------|--------------------------|-------------|\n";
 
     $tbl_output .= "| Level 1    | " . sprintf( "%22d", $n_lvl1) . " | " ;
     $tbl_output .= sprintf("%16d", $MIGRATION_COST{"LVL1"}) . " | ";
     $tbl_output .= sprintf("%24d", $n_lvl1 * $MIGRATION_COST{"LVL1"}) . " | ";
-    $tbl_output .= sprintf( "%8.1f", $n_lvl1 * $MIGRATION_COST{"LVL1"} / $workday_minutes ) . " |\n";
+    $tbl_output .= sprintf( "%11.1f", $n_lvl1 * $MIGRATION_COST{"LVL1"} / $workday_minutes ) . " |\n";
     
     $tbl_output .= "| Level 2    | " . sprintf( "%22d", $n_lvl2) . " | " ;
     $tbl_output .= sprintf("%16d", $MIGRATION_COST{"LVL2"}) . " | " ;
     $tbl_output .= sprintf("%24d", $n_lvl2 * $MIGRATION_COST{"LVL2"}) . " | ";
-    $tbl_output .= sprintf( "%8.1f", $n_lvl2 * $MIGRATION_COST{"LVL2"} / $workday_minutes ) . " |\n";
+    $tbl_output .= sprintf( "%11.1f", $n_lvl2 * $MIGRATION_COST{"LVL2"} / $workday_minutes ) . " |\n";
 
     $tbl_output .= "| Level 3    | " . sprintf( "%22d", $n_lvl3) . " | " ;
     $tbl_output .= sprintf("%16d", $MIGRATION_COST{"LVL3"}) . " | " ;
     $tbl_output .= sprintf("%24d", $n_lvl3 * $MIGRATION_COST{"LVL3"}) . " | ";
-    $tbl_output .= sprintf( "%8.1f", $n_lvl3 * $MIGRATION_COST{"LVL3"} / $workday_minutes ) . " |\n";
+    $tbl_output .= sprintf( "%11.1f", $n_lvl3 * $MIGRATION_COST{"LVL3"} / $workday_minutes ) . " |\n";
 
     $tbl_output .= "| Level 4    | " . sprintf( "%22d", $n_lvl4) . " | " ;
     $tbl_output .= sprintf("%16d", $MIGRATION_COST{"LVL4"}) . " | " ;
     $tbl_output .= sprintf("%24d", $n_lvl4 * $MIGRATION_COST{"LVL4"}) . " | ";
-    $tbl_output .= sprintf( "%8.1f", $n_lvl4 * $MIGRATION_COST{"LVL4"} / $workday_minutes ) . " |\n";
+    $tbl_output .= sprintf( "%11.1f", $n_lvl4 * $MIGRATION_COST{"LVL4"} / $workday_minutes ) . " |\n";
 
 
     if ( $nb_fct_tot == 0 ) {
         $tbl_output .= "| estimation | " . sprintf("%22d", $nb_fct_tot) . " | ";
         $tbl_output .= sprintf( "%16.1f", 0 ) . " | ";
         $tbl_output .= sprintf("%24d", $estimated_load) . " | ";
-        $tbl_output .= sprintf( "%8.1f", $estimated_load_md ) . " |";
+        $tbl_output .= sprintf( "%11.1f", $estimated_load_md ) . " |";
     }
     else {
         $tbl_output .= "| estimation | " . sprintf("%22d", $nb_fct_tot) . " | ";
         $tbl_output .= sprintf( "%16.1f", $estimated_load / $nb_fct_tot );
         $tbl_output .= " | " . sprintf("%24d", $estimated_load) . " | ";
-        $tbl_output .= sprintf( "%8.1f", $estimated_load_md ). " |";
+        $tbl_output .= sprintf( "%11.1f", $estimated_load_md ). " |";
     }
 
     my $orafce_usage = $ORAFCE ? "Yes" : "No";
@@ -3680,7 +3680,7 @@ sub html_output {
     my $n_lvl4             = shift;         # number of level4 instructions
     my $nb_fct_tot         = shift;
     my $estimated_load     = shift;         # total load in minutes
-    my $estimated_load_md  = shift;         # total load in man-days
+    my $estimated_load_md  = shift;         # total load in person-days
     my $ext_to_analyze     = shift;         # the type of extensions to analyze
     my $nb_fic             = shift;
     my $total_nb_lines     = shift;         # number of analyzed lines of code
@@ -3740,7 +3740,7 @@ sub html_output {
 
     $ds_time_by_inst .= qq (],
     datasets: [{
-        label: "Mandays by instructions",
+        label: "Person-days by instructions",
         backgroundColor: "#c10752" ,
         data: [ );
 
@@ -3796,7 +3796,7 @@ sub html_output {
     $ds_diff_by_level .="labels: [\"Level1\",\"Level2\",\"Level3\",\"Level4\"]";
     $ds_diff_by_level .= qq (,
     datasets: [{
-        label: "Man days by difficulty level",
+        label: "Person days by difficulty level",
         backgroundColor: [ "#00c3ff", "#00d16f", "#d1bf00", "#d15000"],
         data: [$n1, $n2, $n3, $n4]
         }
@@ -3948,7 +3948,7 @@ tr:nth-child(even){background-color: #fbfbfb}
     <th>Number of instructions</th>
     <th>Time/instruction</th>
     <th>Estimated time (minutes)</th>
-    <th>Man-days</th>
+    <th>Person-days</th>
   </tr>};
 
     $html .= qq{
@@ -4031,7 +4031,7 @@ tr:nth-child(even){background-color: #fbfbfb}
     # Chart: mandays by instruction
     $html .= qq{
     <p class = "rightgraph">
-        <canvas id="myChartInstructionsManDays"> CANVAS NOT SUPPORTED </canvas>
+        <canvas id="myChartInstructionsPersonDays"> CANVAS NOT SUPPORTED </canvas>
     </p>
     };
 
@@ -4044,7 +4044,7 @@ tr:nth-child(even){background-color: #fbfbfb}
 
     $html .= qq {
         <script>
-            var ctx2 = document.getElementById('myChartInstructionsManDays').getContext('2d');
+            var ctx2 = document.getElementById('myChartInstructionsPersonDays').getContext('2d');
             var chart2 = new Chart(ctx2, {
                 type: 'horizontalBar',
                 data: {
@@ -4206,7 +4206,7 @@ sub main {
     my $nb_files               = 0;   # total number of files parsed
     my $new_nb_fct_total       = 0;
     my $estimated_load         = 0;   # load in minutes
-    my $estimated_load_mandays = 0;   # load in man-days
+    my $estimated_load_mandays = 0;   # load in person-days
     my $analyzed_ext_align     = "";
 
     $matching_lvl_{1} = ();  
@@ -4384,10 +4384,10 @@ sub main {
     }
     else { # $OUTPUT_FORMAT will be "minimal"
         if ($OUTPUT_FILE eq "") {
-            printf ("Estimation: %.2f man-days\n", $estimated_load_mandays );
+            printf ("Estimation: %.2f person-days\n", $estimated_load_mandays );
         }
         else {
-            printf $file_output_handle ("Estimation: %.2f man-days\n", $estimated_load_mandays );
+            printf $file_output_handle ("Estimation: %.2f person-days\n", $estimated_load_mandays );
         }
     }
 
@@ -4434,7 +4434,7 @@ Usage: code2pg
 
 =head1 DESCRIPTION
 
-code2pg will estimate in man-days how difficult a migration from Oracle to 
+code2pg will estimate in person-days how difficult a migration from Oracle to 
 PostgreSQL would be regarding application code. It does not handle the database 
 code as ora2pg does, only the given application code. Therefore, a directory of 
 source code (either files or svn) should be given as input and code2pg will 
@@ -4612,7 +4612,7 @@ Only one extension can be specified at a time.
 =item B<Limitation: tests>
 
 Testing (non regression, functionnal, ...) is not included in the estimation
-and can change rather drastically the cost in man-days.
+and can change rather drastically the cost in person-days.
 
 =back
 

--- a/code2pg
+++ b/code2pg
@@ -110,6 +110,7 @@ my  $RDBMS                  = "";       # the source rdbms instructions
 my  $SHOWVERSION            = "";       # show version and exit
 my  $TAGFILE                = "";       # tag files with special comments ?
 my  $USERNAME               = "";       # username for svn access
+my  @EXCLUDE_INSTR          = "";       # instructions to exlude from analyse
 
 my  $chosen_language        = "";
 my  $chosen_rdbms           = "oracle"; # the source rdbms instructions
@@ -287,6 +288,7 @@ GetOptions(
     'd|directory=s@'        => \$DIRECTORY,
     'D|directorytype=s'     => \$DIRECTORYTYPE,
     'e|extension=s@'        => \$EXTENSION,
+    'E|exclude-instr=s'     => \@EXCLUDE_INSTR,
     'f|format=s'            => \$OUTPUT_FORMAT,
     'l|language=s'          => \$LANGUAGE,
     'o|output-file=s'       => \$OUTPUT_FILE,
@@ -1615,6 +1617,14 @@ sub oracle_init {
     $oracle_functions_list_2{'XMLTYPE'}{'pginstruction'} = 'xml';
     $oracle_functions_list_2{'XMLTYPE'}{'comments'} = q{Oracle's `XMLTYPE` is equivalent to PostgreSQL xml type. Its use is dependant on libxml (can be checked with pg_config). Should be the case on all Redhat like systems.};
     
+    # remove unwanted instruction checks
+    foreach (@EXCLUDE_INSTR)
+    {
+        delete $oracle_functions_list_1{$_};
+        delete $oracle_functions_list_2{$_};
+        delete $oracle_functions_list_3{$_};
+        delete $oracle_functions_list_4{$_};
+    }
 
     return 1;
 }
@@ -2753,6 +2763,15 @@ sub db2_init {
     $db2_functions_list_4{'XMLGROUP'}{'pginstruction'} = 'No equivalent';
     $db2_functions_list_4{'XMLGROUP'}{'sourcedocumentation'} = '';
 
+    # remove unwanted instruction checks
+    foreach (@EXCLUDE_INSTR)
+    {
+        delete $db2_functions_list_1{$_};
+        delete $db2_functions_list_2{$_};
+        delete $db2_functions_list_3{$_};
+        delete $db2_functions_list_4{$_};
+    }
+
     return 1;
 }
 ################################################################################
@@ -3062,6 +3081,15 @@ sub mssql_init {
     $sqlsrv_functions_list_3{'ABS'}{'pginstruction'} = 'abs';
     $sqlsrv_functions_list_3{'ABS'}{'comments'} = q{};
 
+    # remove unwanted instruction checks
+    foreach (@EXCLUDE_INSTR)
+    {
+        delete $sqlsrv_functions_list_1{$_};
+        delete $sqlsrv_functions_list_2{$_};
+        delete $sqlsrv_functions_list_3{$_};
+        delete $sqlsrv_functions_list_4{$_};
+    }
+
     return 1;
 }
 
@@ -3337,6 +3365,8 @@ Usage: code2pg [--option value]
   -D, --directorytype type  : the type of directory to analyze (svn|file)
   -e, --extension ext       : extensions of files to analyze. 
                               Can be used multiple times (-e ext1 -e ext2)
+  -E, --exclude-instr instr : exclude an instruction from analyze because of
+                              too much false positive for example. 
   -f, --format form         : report will be generated in the specified format
                               form = [txt|html|minimal]. Will be html by default
   -h, --help [instr]        : print this help.

--- a/code2pg
+++ b/code2pg
@@ -280,6 +280,13 @@ my %list_orafce_functions = (
     'PUTF'                => '\bPUTF\b',
     'PUT_LINE'            => '\bPUT_LINE\b',
     'TMPDIR'              => '\bTMPDIR\b',
+    'REGEXP_LIKE'         => '\bREGEXP_LIKE\b',
+    'REGEXP_COUNT'        => '\bREGEXP_COUNT\b',
+    'REGEXP_INSTR'        => '\bREGEXP_INSTR\b',
+    'REGEXP_SUBSTR'       => '\bREGEXP_SUBSTR\b',
+    'REGEXP_REPLACE'      => '\bREGEXP_REPLACE\b',
+    'GREATEST'            => '\bGREATEST\b',
+    'LEAST'               => '\bLEAST\b',
 );
 
 
@@ -551,6 +558,7 @@ sub oracle_init {
     $oracle_functions_list_4{'RAWTONHEX'}{'regex'}                    = '\bRAWTONHEX\s*\(';
     $oracle_functions_list_4{'REF'}{'regex'}                          = '\bREF\s*\(';
     $oracle_functions_list_4{'REFTOHEX'}{'regex'}                     = '\bREFTOHEX\s*\(';
+    $oracle_functions_list_4{'REGEXP_COUNT'}{'regex'}                 = '\bREGEXP_COUNT\s*\(';
     $oracle_functions_list_4{'REGEXP_INSTR'}{'regex'}                 = '\bREGEXP_INSTR\s*\(';
     $oracle_functions_list_4{'REGEXP_REPLACE'}{'regex'}               = '\bREGEXP_REPLACE\s*\(';
     $oracle_functions_list_4{'REGEXP_SUBSTR'}{'regex'}                = '\bREGEXP_SUBSTR\s*\(';
@@ -884,7 +892,7 @@ sub oracle_init {
     $oracle_functions_list_3{'GREATEST'}{'sourcedocumentation'} = 'http://docs.oracle.com/database/121/SQLRF/functions078.htm';
     $oracle_functions_list_3{'GREATEST'}{'pgdocumentation'} = 'https://www.postgresql.org/docs/current/static/functions-conditional.html';
     $oracle_functions_list_3{'GREATEST'}{'pginstruction'} = 'greatest';
-    $oracle_functions_list_3{'GREATEST'}{'comments'} = q{Beware of implicit conversions};
+    $oracle_functions_list_3{'GREATEST'}{'comments'} = q{Oracle functions GREATEST return NULL if at least one of the parameters is NULL. This is not the case for the PostgreSQL. Beware of implicit conversions};
     $oracle_functions_list_4{'GROUP_ID'}{'sourcedocumentation'} = 'http://docs.oracle.com/database/121/SQLRF/functions079.htm';
     $oracle_functions_list_4{'GROUP_ID'}{'pgdocumentation'} = '';
     $oracle_functions_list_4{'GROUP_ID'}{'pginstruction'} = '';
@@ -942,7 +950,7 @@ sub oracle_init {
     $oracle_functions_list_3{'LEAST'}{'sourcedocumentation'} = 'http://docs.oracle.com/database/121/SQLRF/functions099.htm';
     $oracle_functions_list_3{'LEAST'}{'pgdocumentation'} = 'https://www.postgresql.org/docs/current/static/functions-conditional.html';
     $oracle_functions_list_3{'LEAST'}{'pginstruction'} = 'least';
-    $oracle_functions_list_3{'LEAST'}{'comments'} = q{Beware of implicit conversions};
+    $oracle_functions_list_3{'LEAST'}{'comments'} = q{Oracle functions LEAST return NULL if at least one of the parameters is NULL. This is not the case for the PostgreSQL. Beware of implicit conversions};
     $oracle_functions_list_2{'LENGTH'}{'sourcedocumentation'} = 'http://docs.oracle.com/database/121/SQLRF/functions100.htm';
     $oracle_functions_list_2{'LENGTH'}{'pgdocumentation'} = 'https://www.postgresql.org/docs/current/static/functions-string.html';
     $oracle_functions_list_2{'LENGTH'}{'pginstruction'} = 'char_length';
@@ -1184,10 +1192,16 @@ sub oracle_init {
     $oracle_functions_list_4{'REGEXP_INSTR'}{'pgdocumentation'} = '';
     $oracle_functions_list_4{'REGEXP_INSTR'}{'pginstruction'} = '';
     $oracle_functions_list_4{'REGEXP_INSTR'}{'comments'} = q{};
-    $oracle_functions_list_3{'REGEXP_LIKE'}{'sourcedocumentation'} = 'https://docs.oracle.com/database/121/SQLRF/conditions007.htm#SQLRF00501';
-    $oracle_functions_list_3{'REGEXP_LIKE'}{'pgdocumentation'} = 'https://www.postgresql.org/docs/current/functions-matching.html';
+    $oracle_functions_list_3{'REGEXP_LIKE'}{'sourcedocumentation'} = 'https://docs.oracle.com/database/121/SQLRF/condit
+ions007.htm#SQLRF00501';
+    $oracle_functions_list_3{'REGEXP_LIKE'}{'pgdocumentation'} = 'https://www.postgresql.org/docs/current/functions-mat
+ching.html';
     $oracle_functions_list_3{'REGEXP_LIKE'}{'pginstruction'} = '~ operator';
     $oracle_functions_list_3{'REGEXP_LIKE'}{'comments'} = q{};
+    $oracle_functions_list_4{'REGEXP_COUNT'}{'sourcedocumentation'} = 'http://docs.oracle.com/database/121/SQLRF/functions161.htm';
+    $oracle_functions_list_4{'REGEXP_COUNT'}{'pgdocumentation'} = '';
+    $oracle_functions_list_4{'REGEXP_COUNT'}{'pginstruction'} = '';
+    $oracle_functions_list_4{'REGEXP_COUNT'}{'comments'} = q{};
     $oracle_functions_list_4{'REGEXP_REPLACE'}{'sourcedocumentation'} = 'http://docs.oracle.com/database/121/SQLRF/functions163.htm';
     $oracle_functions_list_4{'REGEXP_REPLACE'}{'pgdocumentation'} = 'https://www.postgresql.org/docs/current/static/functions-string.html';
     $oracle_functions_list_4{'REGEXP_REPLACE'}{'pginstruction'} = 'regexp_replace';
@@ -3174,9 +3188,7 @@ sub conf_file_handling {
     $file_output = $config_file{"output-file"} if $config_file{"output-file"};
     $directory_output = $config_file{"output-directory"} if $config_file{"output-directory"};
     $csv_file_output = $config_file{"csv-output"} if $config_file{"csv-output"};
-    # $ORAFCE = $config_file{"orafce"} if ($config_file{"orafce"} && $config_file{"orafce"} eq 'on');
     $ORAFCE = ($config_file{"orafce"} eq 'on') if ($config_file{"orafce"}) ;
-    # $TAGFILE = $config_file{"tagfile"} if ($config_file{"tagfile"} && $config_file{"tagfile"} eq 'on');
     $TAGFILE = ($config_file{"tagfile"} eq 'on') if ($config_file{"tagfile"});
     $LEVEL1_MINUTES = $config_file{"level1-minutes"} if $config_file{"level1-minutes"};
     $LEVEL2_MINUTES = $config_file{"level2-minutes"} if $config_file{"level2-minutes"};

--- a/code2pg
+++ b/code2pg
@@ -77,7 +77,9 @@ $REGEX_SEARCH{'tags'}{'after'}  = '(?s:.*?)<';
 # $REGEX_SEARCH{'tags'}{'after'}  = '[\S\s]*?<';
 # $REGEX_SEARCH{'tags'}{'after'}  = '.+?<';  # fast with /gis but not working properly
 $REGEX_SEARCH{'comma-strings'}{'before'} = '".*?'; # in "SQL STRING" 
-$REGEX_SEARCH{'comma-strings'}{'after'}  = '.*?\"';
+$REGEX_SEARCH{'comma-strings'}{'after'}  = '.*?"';
+$REGEX_SEARCH{'perl'}{'before'} = "([\"']).*?"; # in "SQL STRING" 
+$REGEX_SEARCH{'perl'}{'after'}  = ".*?\\1";
 
 ################################################################################
 # Internal variables and constants
@@ -351,7 +353,7 @@ sub oracle_init {
     $oracle_functions_list_1{'COUNT'}{'regex'}               = '\bCOUNT\s*\(';
     $oracle_functions_list_1{'CURRENT_DATE'}{'regex'}        = '\bCURRENT_DATE\b';
     $oracle_functions_list_1{'CURRENT_TIMESTAMP'}{'regex'}   = '\bCURRENT_TIMESTAMP\b';
-    $oracle_functions_list_1{'DELETE_WITHOUT_FROM'}{'regex'} = '\bDELETE(?!\s+FROM\b)';
+    $oracle_functions_list_1{'DELETE_WITHOUT_FROM'}{'regex'} = '\bDELETE(?!\s+FROM\b)\s+';
     $oracle_functions_list_1{'DUAL'}{'regex'}                = '\bFROM\s+DUAL\b';
     $oracle_functions_list_1{'EXP'}{'regex'}                 = '\bEXP\s*\(';
     $oracle_functions_list_1{'FLOOR'}{'regex'}               = '\bFLOOR\s*\(';
@@ -3266,8 +3268,7 @@ sub options_handling {
     }
 
     if ($LANGUAGE) {
-	my @ll = ("plain", "comma-strings", "tags" );
-        if ( grep ( /^$LANGUAGE$/, @ll )) {
+        if ( grep ( /^$LANGUAGE$/, keys %REGEX_SEARCH )) {
 	    $chosen_language = $LANGUAGE; 
         }
         else {
@@ -3376,7 +3377,7 @@ Usage: code2pg [--option value]
 			      specific RDBMS instruction in markdown format.
 			      instr can also be set to "all_instructions" 
   -l, --language lang       : Where the SQL instructions will be looked for.
-                              lang = [plain|comma-strings|tags]
+                              lang = [plain|comma-strings|tags|perl]
   --level1-minutes m        : minutes for a level1 instruction (1 by default)
   --level2-minutes m        : minutes for a level2 instruction (4 by default)
   --level3-minutes m        : minutes for a level3 instruction (8 by default)
@@ -3405,7 +3406,7 @@ Examples:
   ./code2pg -D svn -d https://mysvnrepo/project/trunk -l comma-strings -e java -f txt
   ./code2pg -c myconfigfile.conf
   ./code2pg -h ADD_MONTHS
-  ./code2pg -e pl -e pm --exclude-instr USER -l comma-strings
+  ./code2pg -e pl -e pm --exclude-instr USER -l perl
 
 };
     exit(1);
@@ -4506,7 +4507,7 @@ tag delimited areas.
 
 This should be set together with I<extension> when no configuration file 
 is provided.
-lang = [plain|comma-strings|tags]
+lang = [plain|comma-strings|tags|perl]
 
 =item B<--level1-minutes > integer
 

--- a/code2pg
+++ b/code2pg
@@ -115,6 +115,7 @@ my  $SHOWVERSION            = "";       # show version and exit
 my  $TAGFILE                = "";       # tag files with special comments ?
 my  $USERNAME               = "";       # username for svn access
 my  @EXCLUDE_INSTR          = "";       # instructions to exlude from analyse
+my  $SUPPORTED_CODE         = "";       # should we reported fully supported code?
 
 my  $chosen_language        = "";
 my  $chosen_rdbms           = "oracle"; # the source rdbms instructions
@@ -318,7 +319,9 @@ GetOptions(
     'level4-minutes=i'      => \$LEVEL4_MINUTES,
     'minutes-per-workday=i' => \$MINUTES_PER_WORKDAY,
     'h|help:s'              => \&help_handler,
+    'direct-conversion'     => \$SUPPORTED_CODE,
 );
+
 ################################################################################
 # handling of help switch (with or without parameter)
 
@@ -3352,6 +3355,17 @@ sub options_handling {
         }
     }
 
+    if (!$SUPPORTED_CODE && $chosen_rdbms eq 'oracle') {
+        foreach my $item ( keys %{$rdbms_functions_list_{1}} ) {
+            if ( exists $rdbms_functions_list_{1}{$item} &&
+		    exists $rdbms_functions_list_{1}{$item}{comments} &&
+		    $rdbms_functions_list_{1}{$item}{comments} =~ /Direct conversion/ ) {
+		# print "deleted $rdbms_functions_list_{1}{$item}\n" if ($DEBUG);
+                delete $rdbms_functions_list_{1}{$item};
+            }
+        }
+    }
+
     # we open a file handle but it gets closed very far in the code
     # this should be improved
     my $fo = $directory_output . "/" . $file_output;
@@ -3410,6 +3424,8 @@ Usage: code2pg [--option value]
                               Important: use on a copy of your files.
   -u, --username user       : username for SVN access
   -v, --version             : show script version and exit
+
+  --direct-conversion       : also report fully supported code.
 
 Examples:
 

--- a/code2pg
+++ b/code2pg
@@ -335,7 +335,7 @@ sub oracle_init {
     # ORA_FUNC_1 - each keyword will be matched with a corresponding regex - level 1
     $oracle_functions_list_1{'ABS'}{'regex'}                 = '\bABS\s*\(';
     $oracle_functions_list_1{'ACOS'}{'regex'}                = '\bACOS\s*\(';
-    $oracle_functions_list_1{'ASCII'}{'regex'}               = '\bASCII\b';
+    $oracle_functions_list_1{'ASCII'}{'regex'}               = '\bASCII\s*\(';
     $oracle_functions_list_1{'ASIN'}{'regex'}                = '\bASIN\s*\(';
     $oracle_functions_list_1{'ATAN'}{'regex'}                = '\bATAN\s*\(';
     $oracle_functions_list_1{'ATAN2'}{'regex'}               = '\bATAN2\s*\(';

--- a/doc/code2pg.pod
+++ b/doc/code2pg.pod
@@ -32,7 +32,7 @@ Usage: code2pg
 
 =head1 DESCRIPTION
 
-code2pg will estimate in man-days how difficult a migration from Oracle to 
+code2pg will estimate in person-days how difficult a migration from Oracle to 
 PostgreSQL would be regarding application code. It does not handle the database 
 code as ora2pg does, only the given application code. Therefore, a directory of 
 source code (either files or svn) should be given as input and code2pg will 
@@ -222,7 +222,7 @@ Only one extension can be specified at a time.
 =item B<Limitation: tests>
 
 Testing (non regression, functionnal, ...) is not included in the estimation
-and can change rather drastically the cost in man-days.
+and can change rather drastically the cost in person-days.
 
 =back
 

--- a/doc/code2pg.pod
+++ b/doc/code2pg.pod
@@ -116,7 +116,7 @@ tag delimited areas.
 
 This should be set together with I<extension> when no configuration file 
 is provided.
-lang = [plain|comma-strings|tags]
+lang = [plain|comma-strings|tags|perl]
 
 =item B<--level1-minutes > integer
 

--- a/doc/code2pg.pod
+++ b/doc/code2pg.pod
@@ -11,6 +11,7 @@ Usage: code2pg
 [--directory string]
 [--directorytype string]
 [--extension string]
+[--exclude-instr string]
 [--format string]
 [--help [instr]]
 [--language string]
@@ -78,6 +79,18 @@ dot should be used. This should be set together with I<language> when no
 configuration file is provided.
 
 Can be used multiple times, for eg: ./code2pg -e ext1 -e ext2 ...
+
+=item B<-E>, B<--exclude-instr> string
+
+Specify which instruction will be exclude from analyze, for eg:
+
+    ./code2pg -e jsp -e java -E DELETE_WITHOUT_FROM 
+
+will exclude check of DELETE without FROM in the SQL queries because of too
+much false positive.
+
+Can be used multiple times.
+
 
 =item B<-f> , B<--format> string
 


### PR DESCRIPTION
 This PR include several improvements:

- Fix detection of the Oracle ASCII function.
- Add -E, --exclude-instr command line option to be able to exclude
- Add support to Perl file analyze using extensions pl and pm.
- Add documentation about -E or --exclude-instr option 