### PR TITLE
add json format output

### DIFF
--- a/code2pg
+++ b/code2pg
@@ -44,6 +44,7 @@ use Getopt::Long qw(:config no_ignore_case bundling);
 use File::Find::Rule;
 use List::MoreUtils;
 use Config::General;
+use JSON;
 # use File::Slurp;
 
 ################################################################################
@@ -103,7 +104,7 @@ my  $ORAFCE                 = "";       # will the migration use orafce ?
 my  $OUTPUT_CSV             = "";       # the output listing (csv format)
 my  $OUTPUT_DIRECTORY       = "";       # the output directory
 my  $OUTPUT_FILE            = "";       # the output report (html)
-my  $OUTPUT_FORMAT          = "html";   # report's format (txt, html or minimal)
+my  $OUTPUT_FORMAT          = "html";   # report's format (txt, html, json or minimal)
 my  $PASSWORD               = "";       # password for svn access
 my  $QUIET                  = "";       # silence the script
 my  $RDBMS                  = "";       # the source rdbms instructions
@@ -122,6 +123,7 @@ my  $file_config            = "";       # name of the configuration file
 my  $file_output            = "estimation.html"; # our report file name
 my  $file_output_handle;
 my  $instruction_dataset    = "[";      # the javascript dataset for datatables
+my  $inst_dict_dataset      = ();
 my  $quiet_exec             = 0;        # don't output to stdout
 my  ( $day, $month, $year ) = (localtime)[ 3, 4, 5 ];
 my  $today = sprintf( "%02d/%02d/%04d", $day, $month + 1, $year + 1900 );
@@ -3215,7 +3217,7 @@ sub options_handling {
     }
 
     if ( ( $OUTPUT_FORMAT ne "txt" ) and ( $OUTPUT_FORMAT ne "html" ) and 
-         ( $OUTPUT_FORMAT ne "minimal" ) ) {
+         ( $OUTPUT_FORMAT ne "json" ) and ( $OUTPUT_FORMAT ne "minimal" ) ) {
         print STDERR "Unrecognized output format!\n";
         exit(2);
     }
@@ -3635,6 +3637,44 @@ $tbl_instructions
     }
 
     return 1;
+}
+
+################################################################################
+# printing the json output
+sub json_output {
+    my %niv_               = %{ +shift };
+    my $n_lvl1             = shift;         # number of level1 instructions
+    my $n_lvl2             = shift;         # number of level2 instructions
+    my $n_lvl3             = shift;         # number of level3 instructions
+    my $n_lvl4             = shift;         # number of level4 instructions
+    my $nb_fct_tot         = shift;
+    my $estimated_load     = shift;         # total load in minutes
+    my $estimated_load_md  = shift;         # total load in man-days
+    my $ext_to_analyze     = shift;         # the type of extensions to analyze
+    my $nb_fic             = shift;
+    my $total_nb_lines     = shift;         # number of analyzed lines of code
+
+    my %outdata = (
+        defects        => {
+                            "1"=>$n_lvl1,
+                            "2"=>$n_lvl2,
+                            "3"=>$n_lvl3,
+                            "4"=>$n_lvl4,
+                       },
+        n_fct_tot      => $nb_fct_tot,
+        estimates      => {
+                            minutes => $estimated_load,
+                            mandays => $estimated_load_md,
+                       },
+        nb_files       => $nb_fic,
+        nb_lines       => $total_nb_lines,
+        details        => $inst_dict_dataset,
+        ext_to_analyze => $ext_to_analyze
+    );
+
+    my $jsontext = encode_json({%outdata});
+    print $file_output_handle $jsontext;
+
 }
 
 ################################################################################
@@ -4251,10 +4291,10 @@ sub main {
                     if ($OUTPUT_FORMAT eq "html") {
                         my $mymatch = quotemeta ${^MATCH};
 
-			# we add a comment column in the report and format it properly
-			my $comments = '';
+                        # we add a comment column in the report and format it properly
+                        my $comments = '';
                         if ( defined $rdbms_functions_list_{$level}{$element}{'sourcedocumentation'}) {
-                            $comments .= "<a href=\"$rdbms_functions_list_{$level}{$element}{'sourcedocumentation'}\" target=\"_blank\">Source documentation</a><br/>";
+                                $comments .= "<a href=\"$rdbms_functions_list_{$level}{$element}{'sourcedocumentation'}\" target=\"_blank\">Source documentation</a><br/>";
                         }
                         if ( defined $rdbms_functions_list_{$level}{$element}{'pgdocumentation'}) {
                             $comments .= "<a href=\"$rdbms_functions_list_{$level}{$element}{'pgdocumentation'}\" target=\"_blank\">PostgreSQL documentation</a><br/>";
@@ -4263,13 +4303,40 @@ sub main {
                             $comments .= "PostgreSQL instruction: $rdbms_functions_list_{$level}{$element}{'pginstruction'} <br/>";
                         }
                         if ( defined $rdbms_functions_list_{$level}{$element}{'comments'}) {
-			    my $newcomments = $rdbms_functions_list_{$level}{$element}{'comments'} =~ s/\n/<br\/>/gr; 
-			    $newcomments =~ s/'/&apos;/g; 
-			    $newcomments =~ s/"/&quot;/g; 
-			    $comments .= "Comments: $newcomments <br/>";
+                            my $newcomments = $rdbms_functions_list_{$level}{$element}{'comments'} =~ s/\n/<br\/>/gr;
+                            $newcomments =~ s/'/&apos;/g;
+                            $newcomments =~ s/"/&quot;/g;
+                        $comments .= "Comments: $newcomments <br/>";
                         }
-			my $file_link = '<a href="file:///' . $file .'">' . $file .'</a>';
+                        my $file_link = '<a href="file:///' . $file .'">' . $file .'</a>';
                         $instruction_dataset .= "\n\t['$level', '$file_link', '$line_number', '$element', '$mymatch', '$comments' ],";
+                    }
+                    if ( $OUTPUT_FORMAT eq "json" ) {
+                        my $mymatch = quotemeta ${^MATCH};
+
+                        # we add a comment column in the report and format it properly
+                        my %comments = ();
+                        if ( defined $rdbms_functions_list_{$level}{$element}{'sourcedocumentation'}) {
+                                $comments{'souce_doc'} = $rdbms_functions_list_{$level}{$element}{'sourcedocumentation'};
+                        }
+                        if ( defined $rdbms_functions_list_{$level}{$element}{'pgdocumentation'}) {
+                            $comments{'pgdoc'} = $rdbms_functions_list_{$level}{$element}{'pgdocumentation'};
+                        }
+                        if ( defined $rdbms_functions_list_{$level}{$element}{'pginstruction'}) {
+                            $comments{"pginstruction"} =  $rdbms_functions_list_{$level}{$element}{'pginstruction'};
+                        }
+                        if ( defined $rdbms_functions_list_{$level}{$element}{'comments'}) {
+                            $comments{"comments"} =  $rdbms_functions_list_{$level}{$element}{'comments'};
+                        }
+                        my $row_data = {
+                            level    => $level,
+                            filename => $file,
+                            lineno   => $line_number,
+                            element  => $element,
+                            matching => $mymatch,
+                            comments => {%comments}
+                        };
+                        push(@{$inst_dict_dataset}, $row_data);
                     }
 
                     # use edit-file ?
@@ -4288,7 +4355,7 @@ sub main {
                           . $LANGUAGE_COMMENTS_END{$chosen_language} . "/'";
 			# print "SED COMMAND = `sed -i $sed_command $file`\n" if ($DEBUG);
                         my $sed_res = `sed -i $sed_command "$file"` ;
-                        
+
                         $modified_file = 1;
                     }
                 }
@@ -4297,7 +4364,8 @@ sub main {
 
         # Sed is adding ^M on the files I tried. We remove them.
         if ( $modified_file == 1 ) {
-            my $sed_res = `sed -i 's///g' "$file"`;
+            my $sed_res = `sed -i 's/
+//g' "$file"`;
         }
     }
     print "\rDone !                                                     \n" if (!$quiet_exec);
@@ -4349,6 +4417,17 @@ sub main {
             $nb_analyzed_lines
         );
     }
+    elsif ( $OUTPUT_FORMAT eq "json" ) {
+        json_output(
+            \%matching_lvl_,          $count_lvl_{1},
+            $count_lvl_{2},           $count_lvl_{3},
+            $count_lvl_{4},           $new_nb_fct_total,
+            $estimated_load,          $estimated_load_mandays,
+            $extensions_to_analyze,   $nb_files,
+            $nb_analyzed_lines
+        );
+    }
+
     else { # $OUTPUT_FORMAT will be "minimal"
         if ($OUTPUT_FILE eq "") {
             printf ("Estimation: %.2f man-days\n", $estimated_load_mandays );

--- a/code2pg
+++ b/code2pg
@@ -4364,8 +4364,7 @@ sub main {
 
         # Sed is adding ^M on the files I tried. We remove them.
         if ( $modified_file == 1 ) {
-            my $sed_res = `sed -i 's/
-//g' "$file"`;
+            my $sed_res = `sed -i 's/\r//g' "$file"`;
         }
     }
     print "\rDone !                                                     \n" if (!$quiet_exec);

--- a/doc/code2pg.pod
+++ b/doc/code2pg.pod
@@ -82,7 +82,7 @@ Can be used multiple times, for eg: ./code2pg -e ext1 -e ext2 ...
 =item B<-f> , B<--format> string
 
 The report will be generated according to the specified format. It could be one
-of these values: txt, html or minimal. Defaults to html.
+of these values: txt, html, json or minimal. Defaults to html.
 
 The txt output is markdown compatible.
 


### PR DESCRIPTION
This PR  intends to add json output to code2pg so that restults can be used in various ways to assess several projects code bases.

Some changes are just reformatting.

I just have some doubts about the ^M sed patch that was automagically transformed by editor and I was wondering it there was a way to fix it with `\r` rather than ^M ?

https://github.com/societe-generale/code2pg/compare/master...jcarnu:code2pg:json-output?expand=1#diff-46bb443ce3ce993fdf037f881d6a776c920196050f48d503f8ec6c4349f337cbR4367-R4368

Thus, this PR is not ready yet this problem should be taken into account before merging.